### PR TITLE
Parquet export v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test build
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t parquet-export:pr-${{ github.event.pull_request.number }} .

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ In Cloud Run, authentication is automatic via Workload Identity.
 
 The [config.py](./config.py) file contains the configuration for each database table including:
 
-- `primary_key`: The primary key column name (used for append-only ordering)
+- `order_by`: The column to use for ordering data during export (typically `created_at`). Data is sorted by this column, with `primary_key` as a secondary sort for deterministic ordering.
+- `primary_key`: The primary key column name (used as tie-breaker for append-only ordering)
 - `datatypes`: Column type mappings for proper Parquet schema generation
 - `chunk_size`: Number of rows to fetch per database query
 - `num_chunks_per_file`: Number of chunks to write per Parquet file
@@ -82,6 +83,7 @@ Example:
 {
     'name': 'verified_contracts',
     'primary_key': 'id',
+    'order_by': 'created_at',
     'datatypes': {
         'id': 'Int64',
         'created_at': 'datetime64[ns]',

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Run the script with:
 python main.py
 ```
 
+The script automatically detects existing files in GCS and performs **append-only exports**:
+
+- **First run**: Exports all data from the database
+- **Subsequent runs**:
+  - Finds the newest file in GCS for each table
+  - Downloads it and reads the first row to determine the checkpoint
+  - Regenerates the last file completely (in case it was incomplete)
+  - Exports only new data that arrived since that checkpoint
+
+### Debugging
+
 The script takes some additional env vars for debugging purposes:
 
 - `DEBUG`: Enables debug logging, reduces chunk sizes by 100x, processes only 1 file per table, and skips GCS upload
@@ -54,13 +65,21 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
 
 In Cloud Run, authentication is automatic via Workload Identity.
 
-The [config.py](./config.py) file contains the configuration for each database table about the chunk sizes and number of chunks per file, and the datatypes for each column in the table.
+### Configuration
+
+The [config.py](./config.py) file contains the configuration for each database table including:
+
+- `primary_key`: The primary key column name (used for append-only ordering)
+- `datatypes`: Column type mappings for proper Parquet schema generation
+- `chunk_size`: Number of rows to fetch per database query
+- `num_chunks_per_file`: Number of chunks to write per Parquet file
 
 Example:
 
-```js
-  {
+```python
+{
     'name': 'verified_contracts',
+    'primary_key': 'id',
     'datatypes': {
         'id': 'Int64',
         'created_at': 'datetime64[ns]',
@@ -70,20 +89,24 @@ Example:
         'deployment_id': 'string',
         'compilation_id': 'string',
         'creation_match': 'bool',
-        'creation_values': 'string',
-        'creation_transformations': 'string',
+        'creation_values': 'json',
+        'creation_transformations': 'json',
         'runtime_match': 'bool',
-        'runtime_values': 'string',
-        'runtime_transformations': 'string'
+        'runtime_values': 'json',
+        'runtime_transformations': 'json',
+        'runtime_metadata_match': 'bool',
+        'creation_metadata_match': 'bool'
     },
-    'chunk_size': 10000,
+    'chunk_size': 100000,
     'num_chunks_per_file': 10
-  }
+}
 ```
 
-This config gives `10,000 * 10 = 100,000` rows per file.
+This config gives `100,000 * 10 = 1,000,000` rows per file.
 
-The files will be named `verified_contracts_0_100000_zstd.parquet` and `verified_contracts_100000_200000_zstd.parquet` etc. (`zstd` is the compression algorithm).
+The files will be named `verified_contracts_0_1000000.parquet`, `verified_contracts_1000000_2000000.parquet`, etc.
+
+Files are stored in GCS under the `v2/{table_name}/` prefix.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This config gives `100,000 * 10 = 1,000,000` rows per file.
 
 The files will be named `verified_contracts_0_1000000.parquet`, `verified_contracts_1000000_2000000.parquet`, etc.
 
-Files are stored in GCS under the `v2/{table_name}/` prefix.
+Files are stored in GCS under the `v2/{table_name}/` prefix and compressed using zstd.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,21 @@
 
 Python scripts and Docker container to export the Verifier Alliance PostgreSQL database in Parquet format and upload it to Google Cloud Storage.
 
-The latest export is publicly available at [https://export.verifieralliance.org](https://export.verifieralliance.org).
-
 The export script has undergone a redesign which made it append-only. The new export format is referred to as "v2". See https://github.com/argotorg/sourcify/issues/2441 for details of the redesign.
 
-## Requirements
+## Downloading the public dataset
+
+The latest export is publicly available at [https://export.verifieralliance.org](https://export.verifieralliance.org).
+
+Please refer to the [VerA docs](https://verifieralliance.org/docs/download) for instructions on how to download and use the Parquet files.
+
+## Running the Export Script
+
+### Requirements
 
 - Python 3
 
-## Installation
+### Installation
 
 Create a virtual environment:
 
@@ -30,7 +36,7 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
-## Usage
+### Usage
 
 Run the script with:
 
@@ -112,7 +118,7 @@ The files will be named `verified_contracts_0_1000000.parquet`, `verified_contra
 
 Files are stored in GCS under the `v2/{table_name}/` prefix and compressed using zstd.
 
-## Docker
+### Docker
 
 Build the image:
 
@@ -133,3 +139,5 @@ Previously, the export script generated a `manifest.json` file containing metada
 For example, this API endpoint lists all available export v2 files with their metadata in XML:
 
 https://export.test.verifieralliance.org/?prefix=v2/
+
+This API is compatible with the AWS S3 API. Documentation can be found here: https://docs.cloud.google.com/storage/docs/xml-api/get-bucket-list

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Python scripts and Docker container to export the Verifier Alliance PostgreSQL d
 
 The latest export is publicly available at [https://export.verifieralliance.org](https://export.verifieralliance.org).
 
+The export script has undergone a redesign which made it append-only. The new export format is referred to as "v2". See https://github.com/argotorg/sourcify/issues/2441 for details of the redesign.
+
 ## Requirements
 
 - Python 3
@@ -121,3 +123,11 @@ Publish:
 ```
 docker push kuzdogan/test-parquet-linux
 ```
+
+## Metadata
+
+Previously, the export script generated a `manifest.json` file containing metadata about the export. This is no longer generated, as we now rely on the Google Cloud Storage API for metadata.
+
+For example, this API endpoint lists all available export v2 files with their metadata in XML:
+
+https://export.test.verifieralliance.org/?prefix=v2/

--- a/README.md
+++ b/README.md
@@ -85,30 +85,6 @@ This config gives `10,000 * 10 = 100,000` rows per file.
 
 The files will be named `verified_contracts_0_100000_zstd.parquet` and `verified_contracts_100000_200000_zstd.parquet` etc. (`zstd` is the compression algorithm).
 
-The script also generates a `manifest.json` that contains a timestamp when the dump is created, and the list of files uploaded to Google Cloud Storage.
-
-```json
-{
-  "timestamp": 1718042395518,
-  "dateStr": "2024-06-10T17:59:55.518972Z",
-  "files": {
-    "code": [
-      "code/code_0_100000_zstd.parquet",
-      "code/code_100000_200000_zstd.parquet",
-      "code/code_200000_300000_zstd.parquet",
-      "code/code_300000_400000_zstd.parquet",
-      "code/code_400000_500000_zstd.parquet",
-      "code/code_500000_600000_zstd.parquet",
-      "code/code_600000_700000_zstd.parquet",
-      "code/code_700000_800000_zstd.parquet"
-    ],
-    "contract_deployments": [...],
-    "compiled_contracts": [...],
-    "verified_contracts": [...]
-  }
-}
-```
-
 ## Docker
 
 Build the image:

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ tables_config = [
     {
         'name': 'code',
         'primary_key': 'code_hash',
+        'order_by': 'created_at',
         'datatypes': {
             'code_hash': 'object',
             'code': 'object',
@@ -20,6 +21,7 @@ tables_config = [
     {
         'name': 'contracts',
         'primary_key': 'id',
+        'order_by': 'created_at',
         'datatypes': {
             'id': 'string',
             'creation_code_hash': 'object',
@@ -35,6 +37,7 @@ tables_config = [
     {
         'name': 'contract_deployments',
         'primary_key': 'id',
+        'order_by': 'created_at',
         'datatypes': {
             'id': 'string',
             'chain_id': 'Int64',
@@ -55,6 +58,7 @@ tables_config = [
     {
         'name': 'compiled_contracts',
         'primary_key': 'id',
+        'order_by': 'created_at',
         'datatypes': {
             'id': 'string',
             'created_at': 'datetime64[ns]',
@@ -79,6 +83,7 @@ tables_config = [
     {
         'name': 'compiled_contracts_sources',
         'primary_key': 'id',
+        'order_by': 'created_at',
         'datatypes': {
             'id': 'string',
             'compilation_id': 'string',
@@ -92,6 +97,7 @@ tables_config = [
     {
         'name': 'sources',
         'primary_key': 'source_hash',
+        'order_by': 'created_at',
         'datatypes': {
             'source_hash': 'object',
             'source_hash_keccak': 'object',
@@ -107,6 +113,7 @@ tables_config = [
     {
         'name': 'verified_contracts',
         'primary_key': 'id',
+        'order_by': 'created_at',
         'datatypes': {
             'id': 'Int64',
             'created_at': 'datetime64[ns]',

--- a/config.py
+++ b/config.py
@@ -4,6 +4,7 @@
 tables_config = [
     {
         'name': 'code',
+        'primary_key': 'code_hash',
         'datatypes': {
             'code_hash': 'object',
             'code': 'object',
@@ -18,6 +19,7 @@ tables_config = [
     },
     {
         'name': 'contracts',
+        'primary_key': 'id',
         'datatypes': {
             'id': 'string',
             'creation_code_hash': 'object',
@@ -32,6 +34,7 @@ tables_config = [
     },
     {
         'name': 'contract_deployments',
+        'primary_key': 'id',
         'datatypes': {
             'id': 'string',
             'chain_id': 'Int64',
@@ -51,6 +54,7 @@ tables_config = [
     },
     {
         'name': 'compiled_contracts',
+        'primary_key': 'id',
         'datatypes': {
             'id': 'string',
             'created_at': 'datetime64[ns]',
@@ -74,6 +78,7 @@ tables_config = [
     },
     {
         'name': 'compiled_contracts_sources',
+        'primary_key': 'id',
         'datatypes': {
             'id': 'string',
             'compilation_id': 'string',
@@ -86,6 +91,7 @@ tables_config = [
     },
     {
         'name': 'sources',
+        'primary_key': 'source_hash',
         'datatypes': {
             'source_hash': 'object',
             'source_hash_keccak': 'object',
@@ -100,6 +106,7 @@ tables_config = [
     },
     {
         'name': 'verified_contracts',
+        'primary_key': 'id',
         'datatypes': {
             'id': 'Int64',
             'created_at': 'datetime64[ns]',

--- a/config.py
+++ b/config.py
@@ -78,7 +78,8 @@ tables_config = [
             'id': 'string',
             'compilation_id': 'string',
             'source_hash': 'object',
-            'path': 'string'
+            'path': 'string',
+            'created_at': 'datetime64[ns]',
         },
         'chunk_size': 100000,
         'num_chunks_per_file': 10

--- a/main.py
+++ b/main.py
@@ -185,15 +185,15 @@ def get_newest_file_from_gcs(table_name, bucket_name):
         logger.error(f"Error finding newest file in GCS: {e}")
         raise
 
-def download_and_read_first_row(blob_name, bucket_name, primary_key):
+def download_and_read_first_row(blob_name, bucket_name, order_by_column, primary_key):
     """
-    Download a Parquet file from GCS, read the first row to extract (created_at, primary_key_value),
+    Download a Parquet file from GCS, read the first row to extract (order_by_value, primary_key_value),
     then delete the local file. This determines where the file starts for regenerating it.
-    Returns (created_at_timestamp, primary_key_value) tuple.
+    Returns (order_by_value, primary_key_value) tuple.
     """
     logger.info(f"Downloading {blob_name} from GCS to read first row")
     local_file = f"temp_{blob_name.split('/')[-1]}"
-    
+
     try:
         client = storage.Client()
         bucket = client.bucket(bucket_name)
@@ -209,16 +209,16 @@ def download_and_read_first_row(blob_name, bucket_name, primary_key):
 
         # Get the first row to determine where this file starts (for regenerating the entire file)
         first_row = df.iloc[0]
-        created_at = first_row['created_at']
+        order_by_value = first_row[order_by_column]
         primary_key_value = first_row[primary_key]
 
-        logger.info(f"First row: created_at={created_at}, {primary_key}={primary_key_value}")
+        logger.info(f"First row: {order_by_column}={order_by_value}, {primary_key}={primary_key_value}")
 
         # Delete the temporary file
         os.remove(local_file)
         logger.info(f"Deleted temporary file {local_file}")
 
-        return created_at, primary_key_value
+        return order_by_value, primary_key_value
 
     except Exception as e:
         logger.error(f"Error downloading and reading file from GCS: {e}")
@@ -231,6 +231,7 @@ def fetch_and_write(table_config, engine):
     postgres_schema_name = os.getenv('DB_SCHEMA')
     table_name = table_config['name']
     primary_key = table_config['primary_key']
+    order_by_column = table_config['order_by']
     dtypes = table_config['datatypes']
     schema = get_pyarrow_schema(dtypes)
     chunk_size = table_config['chunk_size']
@@ -248,7 +249,7 @@ def fetch_and_write(table_config, engine):
     bucket_name = os.getenv('GCS_BUCKET_NAME')
     newest_blob_name = get_newest_file_from_gcs(table_name, bucket_name)
 
-    resume_from_created_at = None
+    resume_from_order_by = None
     resume_from_pk = None
 
     if newest_blob_name:
@@ -262,8 +263,8 @@ def fetch_and_write(table_config, engine):
         logger.info(f"Resuming from file: {newest_file_name}, file_counter: {file_counter}")
 
         # Download and read the first row to get checkpoint
-        resume_from_created_at, resume_from_pk = download_and_read_first_row(newest_blob_name, bucket_name, primary_key)
-        logger.info(f"Resume checkpoint: created_at={resume_from_created_at}, {primary_key}={resume_from_pk}")
+        resume_from_order_by, resume_from_pk = download_and_read_first_row(newest_blob_name, bucket_name, order_by_column, primary_key)
+        logger.info(f"Resume checkpoint: {order_by_column}={resume_from_order_by}, {primary_key}={resume_from_pk}")
 
     # Determine if primary key needs UUID casting (when dtype is 'string', it's a UUID in the database)
     pk_is_uuid = dtypes.get(primary_key) == 'string'
@@ -273,26 +274,26 @@ def fetch_and_write(table_config, engine):
     with engine.connect().execution_options(stream_results=True) as connection:
 
         # Build query with composite ordering and optional WHERE clause for resuming
-        if resume_from_created_at is not None:
+        if resume_from_order_by is not None:
             if pk_is_uuid:
                 pk_comparison = f"{primary_key} >= :pk_value::uuid"
             else:
                 pk_comparison = f"{primary_key} >= :pk_value"
 
-            # Query for append-only: WHERE (created_at > ?) OR (created_at = ? AND primary_key >= ?)
+            # Query for append-only: WHERE (order_by_column > ?) OR (order_by_column = ? AND primary_key >= ?)
             query = text(f"""
                 SELECT * FROM {postgres_schema_name}.{table_name}
-                WHERE (created_at > :created_at) OR (created_at = :created_at AND {pk_comparison})
-                ORDER BY created_at ASC, {primary_key} ASC
+                WHERE ({order_by_column} > :order_by_value) OR ({order_by_column} = :order_by_value AND {pk_comparison})
+                ORDER BY {order_by_column} ASC, {primary_key} ASC
             """)
-            query = query.bindparams(created_at=resume_from_created_at, pk_value=resume_from_pk)
+            query = query.bindparams(order_by_value=resume_from_order_by, pk_value=resume_from_pk)
         else:
             # Full export from the beginning
-            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC, {primary_key} ASC")
+            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY {order_by_column} ASC, {primary_key} ASC")
 
         if os.getenv('DEBUG_OFFSET'):
             # Override with debug offset if set
-            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC, {primary_key} ASC OFFSET {os.getenv('DEBUG_OFFSET')}")
+            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY {order_by_column} ASC, {primary_key} ASC OFFSET {os.getenv('DEBUG_OFFSET')}")
 
         logger.info(f"Executing query for table {table_name}: {query}")
 

--- a/main.py
+++ b/main.py
@@ -86,11 +86,8 @@ def create_sqlalchemy_engine() -> Engine:
         engine = create_engine(connection_string)
     return engine
 
-def get_output_file(table_name, compression):
-    if compression:
-        return f"{table_name}_{compression}.parquet"
-    else:
-        return f"{table_name}.parquet"
+def get_output_file(file_name):
+    return f"{file_name}.parquet"
 
 def convert_memoryview_to_bytes(data):
     return data.tobytes() if isinstance(data, memoryview) else data
@@ -159,9 +156,81 @@ def upload_to_gcs(file_path, bucket_name, object_name):
         logger.error(f"Error uploading to GCS: {e}")
         raise
 
+def get_newest_file_from_gcs(table_name, bucket_name):
+    """
+    Find the newest file for a given table in GCS based on last modified timestamp.
+    Returns blob_name (full path) or None if no files exist.
+    """
+    logger.info(f"Searching for newest file in GCS for table: {table_name}")
+
+    try:
+        client = storage.Client()
+        bucket = client.bucket(bucket_name)
+
+        # List all blobs in the table's directory (under v2/)
+        prefix = f"v2/{table_name}/"
+        blobs = list(bucket.list_blobs(prefix=prefix))
+
+        if not blobs:
+            logger.info(f"No existing files found in GCS for table {table_name}")
+            return None
+
+        # Find the blob with the latest updated timestamp
+        newest_blob = max(blobs, key=lambda b: b.updated)
+        logger.info(f"Found newest file: {newest_blob.name} (updated: {newest_blob.updated})")
+
+        return newest_blob.name
+
+    except Exception as e:
+        logger.error(f"Error finding newest file in GCS: {e}")
+        raise
+
+def download_and_read_first_row(blob_name, bucket_name, primary_key):
+    """
+    Download a Parquet file from GCS, read the first row to extract (created_at, primary_key_value),
+    then delete the local file. This determines where the file starts for regenerating it.
+    Returns (created_at_timestamp, primary_key_value) tuple.
+    """
+    logger.info(f"Downloading {blob_name} from GCS to read first row")
+    local_file = f"temp_{blob_name.split('/')[-1]}"
+    
+    try:
+        client = storage.Client()
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+
+        # Download to a temporary local file
+        blob.download_to_filename(local_file)
+        logger.info(f"Downloaded {blob_name} to {local_file}")
+
+        # Read the Parquet file
+        table = pq.read_table(local_file)
+        df = table.to_pandas()
+
+        # Get the first row to determine where this file starts (for regenerating the entire file)
+        first_row = df.iloc[0]
+        created_at = first_row['created_at']
+        primary_key_value = first_row[primary_key]
+
+        logger.info(f"First row: created_at={created_at}, {primary_key}={primary_key_value}")
+
+        # Delete the temporary file
+        os.remove(local_file)
+        logger.info(f"Deleted temporary file {local_file}")
+
+        return created_at, primary_key_value
+
+    except Exception as e:
+        logger.error(f"Error downloading and reading file from GCS: {e}")
+        # Clean up temp file if it exists
+        if os.path.exists(local_file):
+            os.remove(local_file)
+        raise
+
 def fetch_and_write(table_config, engine):
     postgres_schema_name = os.getenv('DB_SCHEMA')
     table_name = table_config['name']
+    primary_key = table_config['primary_key']
     dtypes = table_config['datatypes']
     schema = get_pyarrow_schema(dtypes)
     chunk_size = table_config['chunk_size']
@@ -176,14 +245,48 @@ def fetch_and_write(table_config, engine):
     file_counter = 0
     writer = None
 
+    # Check for existing files in GCS to enable append-only export
+    bucket_name = os.getenv('GCS_BUCKET_NAME')
+    newest_blob_name = get_newest_file_from_gcs(table_name, bucket_name)
+
+    resume_from_created_at = None
+    resume_from_pk = None
+
+    if newest_blob_name:
+        # Extract the filename from the full blob path and parse it
+        # Format: table_name/table_name_start_end.parquet
+        newest_file_name = newest_blob_name.split('/')[-1]
+        parts = newest_file_name.replace(f"{table_name}_", "").replace(".parquet", "").split("_")
+        start_row = int(parts[0])
+        file_counter = start_row // rows_per_file
+
+        logger.info(f"Resuming from file: {newest_file_name}, file_counter: {file_counter}")
+
+        # Download and read the first row to get checkpoint
+        resume_from_created_at, resume_from_pk = download_and_read_first_row(newest_blob_name, bucket_name, primary_key)
+        logger.info(f"Resume checkpoint: created_at={resume_from_created_at}, {primary_key}={resume_from_pk}")
+
     # Use stream_results=True to fetch data in chunks
     logger.info(f"Connecting to the DB for the table: {table_name}")
     with engine.connect().execution_options(stream_results=True) as connection:
 
+        # Build query with composite ordering and optional WHERE clause for resuming
+        if resume_from_created_at is not None:
+            # Query for append-only: WHERE (created_at > ?) OR (created_at = ? AND primary_key >= ?)
+            query = text(f"""
+                SELECT * FROM {postgres_schema_name}.{table_name}
+                WHERE (created_at > :created_at) OR (created_at = :created_at AND {primary_key} >= :pk_value)
+                ORDER BY created_at ASC, {primary_key} ASC
+            """)
+            query = query.bindparams(created_at=resume_from_created_at, pk_value=resume_from_pk)
+        else:
+            # Full export from the beginning
+            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC, {primary_key} ASC")
 
-        query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC")
         if os.getenv('DEBUG_OFFSET'):
-            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC OFFSET {os.getenv('DEBUG_OFFSET')}")
+            # Override with debug offset if set
+            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC, {primary_key} ASC OFFSET {os.getenv('DEBUG_OFFSET')}")
+
         logger.info(f"Executing query for table {table_name}: {query}")
 
         start_time = time.time()
@@ -202,8 +305,8 @@ def fetch_and_write(table_config, engine):
             chunk_table = pa.Table.from_pandas(df, schema=schema) # Convert the dataframe to a PyArrow table
 
             if writer is None:
-                # file name: contracts_0_10000_zstd.parquet, contracts_10000_20000_zstd.parquet, etc.
-                output_file = get_output_file(f"{table_name}_{file_counter * rows_per_file}_{(file_counter + 1) * rows_per_file}", compression)
+                # file name: contracts_0_10000.parquet, contracts_10000_20000.parquet, etc.
+                output_file = get_output_file(f"{table_name}_{file_counter * rows_per_file}_{(file_counter + 1) * rows_per_file}")
                 writer = pq.ParquetWriter(output_file, chunk_table.schema, compression=compression)
 
             logger.info(f"Writing chunk {chunk_counter} of file {file_counter} to {output_file}")

--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ def get_google_conn() -> pg8000.dbapi.Connection:
             "pg8000",
             user=os.getenv('DB_USER'),
             password=os.getenv('DB_PASSWORD'),
-            db=os.getenv('DB_NAME'), 
+            db=os.getenv('DB_NAME'),
             ip_type=IPTypes.PUBLIC
         )
         logger.info("Successfully created Google Cloud SQL connection")
@@ -265,16 +265,24 @@ def fetch_and_write(table_config, engine):
         resume_from_created_at, resume_from_pk = download_and_read_first_row(newest_blob_name, bucket_name, primary_key)
         logger.info(f"Resume checkpoint: created_at={resume_from_created_at}, {primary_key}={resume_from_pk}")
 
+    # Determine if primary key needs UUID casting (when dtype is 'string', it's a UUID in the database)
+    pk_is_uuid = dtypes.get(primary_key) == 'string'
+
     # Use stream_results=True to fetch data in chunks
     logger.info(f"Connecting to the DB for the table: {table_name}")
     with engine.connect().execution_options(stream_results=True) as connection:
 
         # Build query with composite ordering and optional WHERE clause for resuming
         if resume_from_created_at is not None:
+            if pk_is_uuid:
+                pk_comparison = f"{primary_key} >= :pk_value::uuid"
+            else:
+                pk_comparison = f"{primary_key} >= :pk_value"
+
             # Query for append-only: WHERE (created_at > ?) OR (created_at = ? AND primary_key >= ?)
             query = text(f"""
                 SELECT * FROM {postgres_schema_name}.{table_name}
-                WHERE (created_at > :created_at) OR (created_at = :created_at AND {primary_key} >= :pk_value)
+                WHERE (created_at > :created_at) OR (created_at = :created_at AND {pk_comparison})
                 ORDER BY created_at ASC, {primary_key} ASC
             """)
             query = query.bindparams(created_at=resume_from_created_at, pk_value=resume_from_pk)

--- a/main.py
+++ b/main.py
@@ -238,7 +238,6 @@ def fetch_and_write(table_config, engine):
         logger.debug(f"DEBUG: Setting chunk_size to 1/100 of {chunk_size} = {chunk_size // 100}")
         chunk_size = chunk_size // 100
 
-    compression = table_config.get('compression', None)
     num_chunks_per_file = table_config['num_chunks_per_file']
     rows_per_file = chunk_size * num_chunks_per_file
     chunk_counter = 0

--- a/main.py
+++ b/main.py
@@ -12,13 +12,9 @@ import time
 import logging
 import pg8000
 import json
-from datetime import datetime 
 
 # Load environment variables from .env file
 load_dotenv()
-
-# Global dictionary to store uploaded files. To be written to the manifest.json
-uploaded_files = {}
 
 compression = 'zstd'
 
@@ -98,19 +94,6 @@ def get_output_file(table_name, compression):
 
 def convert_memoryview_to_bytes(data):
     return data.tobytes() if isinstance(data, memoryview) else data
-
-def write_manifest():
-    timestamp = int(datetime.now().timestamp() * 1000)
-    date_str = datetime.now().isoformat() + "Z"
-    manifest = {
-        "timestamp": timestamp,
-        "dateStr": date_str,
-        "files": uploaded_files
-    }
-    with open('manifest.json', 'w') as f:
-        json.dump(manifest, f, indent=2)
-    logger.info("Manifest file written successfully.")
-
 
 def process_df(df, dtypes):
     for col in ['created_at', 'updated_at']:
@@ -238,11 +221,6 @@ def fetch_and_write(table_config, engine):
                 object_name = f"{table_name}/{output_file}"
                 upload_to_gcs(output_file, os.getenv('GCS_BUCKET_NAME'), object_name)
 
-                # Append the file to the uploaded files list to be written to the manifest.json
-                if table_name not in uploaded_files:
-                    uploaded_files[table_name] = []
-                uploaded_files[table_name].append(object_name)
-
                 file_counter += 1
                 chunk_counter = 0
                 writer = None  # Reset the writer for the next file
@@ -257,11 +235,6 @@ def fetch_and_write(table_config, engine):
             # Upload the file to GCS
             object_name = f"{table_name}/{output_file}"
             upload_to_gcs(output_file, os.getenv('GCS_BUCKET_NAME'), object_name)
-            
-            # Append the file to the uploaded files list to be written to the manifest.json
-            if table_name not in uploaded_files:
-                uploaded_files[table_name] = []
-            uploaded_files[table_name].append(object_name)
 
 
 if __name__ == "__main__":
@@ -279,5 +252,3 @@ if __name__ == "__main__":
         for table_config in tables_config:
             logger.info(f"Fetching and writing table: {table_config['name']}")
             fetch_and_write(table_config, engine)
-    write_manifest()  # Write the manifest file after processing all tables
-    upload_to_gcs('manifest.json', os.getenv('GCS_BUCKET_NAME'), 'manifest.json')

--- a/main.py
+++ b/main.py
@@ -152,6 +152,7 @@ def get_pyarrow_schema(dtypes):
     return pa.schema([pa.field(col, get_pyarrow_type(dt)) for col, dt in dtypes.items()])
 
 def upload_to_gcs(file_path, bucket_name, object_name):
+    object_name = f'v2/{object_name}'
     logger.info(f"Uploading {object_name} to GCS")
     if os.getenv("DEBUG"):
         logger.debug("DEBUG: NOT uploading to GCS in DEBUG mode")

--- a/main.py
+++ b/main.py
@@ -197,9 +197,9 @@ def fetch_and_write(table_config, engine):
     with engine.connect().execution_options(stream_results=True) as connection:
 
 
-        query = text(f"SELECT * FROM {postgres_schema_name}.{table_name}")
+        query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC")
         if os.getenv('DEBUG_OFFSET'):
-            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} OFFSET {os.getenv('DEBUG_OFFSET')}")
+            query = text(f"SELECT * FROM {postgres_schema_name}.{table_name} ORDER BY created_at ASC OFFSET {os.getenv('DEBUG_OFFSET')}")
         logger.info(f"Executing query for table {table_name}: {query}")
 
         start_time = time.time()

--- a/main.py
+++ b/main.py
@@ -276,7 +276,7 @@ def fetch_and_write(table_config, engine):
         # Build query with composite ordering and optional WHERE clause for resuming
         if resume_from_order_by is not None:
             if pk_is_uuid:
-                pk_comparison = f"{primary_key} >= :pk_value::uuid"
+                pk_comparison = f"{primary_key} >= CAST(:pk_value AS uuid)"
             else:
                 pk_comparison = f"{primary_key} >= :pk_value"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jmespath==1.0.1
 multidict==6.0.5
 numpy==1.26.4
 pandas==2.2.2
-pg8000==1.31.2
+pg8000==1.31.5
 psycopg2==2.9.9
 pyarrow==16.1.0
 pyasn1==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ six==1.16.0
 SQLAlchemy==2.0.30
 typing_extensions==4.11.0
 tzdata==2024.1
-urllib3==2.2.1
+urllib3==2.6.0
 yarl==1.9.4


### PR DESCRIPTION
See https://github.com/argotorg/sourcify/issues/2441

Highlights:

- **Append-only export**: New data goes into new files, old ones don't need to be rewritten. Script automatically resumes from the last parquet file and only rewrites the last one (because it might not have been full).
- **Compression**: Thanks to zstd compression export files are now only around 15 % of the original size. Compression is integrated in the parquet format.
- **Removal of manifest.json**: Instead of generating all of the metadata ourselves, we can simply rely on the default GCP Storage Bucket API (see README, conformant to AWS S3 API). Unfortunately, for this, I had to remove the redirect to the manifest.json at the base URL https://export.test.verifieralliance.org/. This means we will break people's implementations. They would still be able to query the v1 export via https://export.test.verifieralliance.org/manifest.json.
- **Metadata including checksum, upload date and size per file**: The GCP Storage Bucket API provides all of the metadata which has been requested in the past.